### PR TITLE
Update tutorial.rst to help with "mlflow run tutorial"  and "mlflow serve sklearn" tutorial code

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -280,7 +280,7 @@ Packaging the Training Code
             - pip:
               - mlflow
 
-      To run this project, invoke ``mlflow run tutorial -P alpha=0.42``. After running
+      To run this project, from the ``examples`` folder, invoke ``mlflow run sklearn_elasticnet_wine -P alpha=0.42``. After running
       this command, MLflow will run your training code in a new Conda environment with the dependencies
       specified in ``conda.yaml``.
 
@@ -376,6 +376,12 @@ Serving the Model
       .. code::
 
           mlflow sklearn serve /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234
+          
+      To deploy the server using your own model artifact, copy the path to your ``model`` folder using the same UI approach as above. Then run:
+      
+      .. code::
+      
+          mlflow sklearn serve -m PATH_TO_YOUR_MODEL -p 1234
 
       .. note::
 


### PR DESCRIPTION
The python tutorial instructions didn't work for me for the "Packaging training code" and "Serving the model" sections. I followed the previous instructions with no problem, but then had to do some trial and error to figure out which directory I should be in when executing the instructions. 

Specifically, `mlflow run tutorial -P alpha=0.42` did not work for me at all (even when changing directories), whilst for `mlflow sklearn serve /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234` it is not clear that you should put in your own artifact path or use the `-m` flag.

I've tried to update the documentation accordingly - but it might not be what you're after! Happy to try again.